### PR TITLE
build: use debian:bookworm-slim runtime instead of distroless

### DIFF
--- a/kraft-core/Containerfile
+++ b/kraft-core/Containerfile
@@ -46,7 +46,10 @@ RUN groupadd -g 10001 nonroot \
     && useradd -u 10001 -g 10001 -M -s /sbin/nologin nonroot \
     && install -d -o 10001 -g 10001 /home/nonroot
 
-FROM gcr.io/distroless/cc-debian12
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=runtime-prep /etc/passwd /etc/passwd
 COPY --from=runtime-prep /etc/group  /etc/group
 COPY --from=runtime-prep --chown=10001:10001 /home/nonroot /home/nonroot

--- a/workspace/sidecar/Containerfile
+++ b/workspace/sidecar/Containerfile
@@ -46,7 +46,10 @@ RUN groupadd -g 10001 nonroot \
     && useradd -u 10001 -g 10001 -M -s /sbin/nologin nonroot \
     && install -d -o 10001 -g 10001 /home/nonroot
 
-FROM gcr.io/distroless/cc-debian12
+FROM debian:bookworm-slim
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=runtime-prep /etc/passwd /etc/passwd
 COPY --from=runtime-prep /etc/group  /etc/group
 COPY --from=runtime-prep --chown=10001:10001 /home/nonroot /home/nonroot


### PR DESCRIPTION
Switch the runtime base image for `kraft-core` and `workspace-sidecar` from `gcr.io/distroless/cc-debian12` to `debian:bookworm-slim`, matching the towonel node image.

## Changes
- `kraft-core/Containerfile`: runtime base → `debian:bookworm-slim`
- `workspace/sidecar/Containerfile`: runtime base → `debian:bookworm-slim`
- Install `ca-certificates` in both. The `distroless/cc` image bundled them; the slim image does not, and both binaries make outbound TLS calls via rustls.

The `runtime-prep` stage, nonroot user (10001), workdir, and entrypoints are unchanged.